### PR TITLE
fixed LAPACK/BLAS detection for old cmake.

### DIFF
--- a/cmake/Packages/LAPACK.cmake
+++ b/cmake/Packages/LAPACK.cmake
@@ -16,6 +16,7 @@ LIST (APPEND _blas_vendors "OpenBLAS" "Goto" "ATLAS" "Apple" "Generic")
 
 # old CMake doesn't know that OpenBLAS is a BLAS
 IF (${CMAKE_VERSION} VERSION_LESS 3.6)
+  FIND_PACKAGE (LAPACK QUIET)
   IF (NOT LAPACK_FOUND)
     set(_vendor OpenBLAS)
     FIND_PACKAGE(${_vendor} QUIET)


### PR DESCRIPTION
On Ubuntu 16.04, cmake 3.5, and libopenblas-dev installed this would fail to find LAPACK/BLAS initially, run through the five vendors and eventually settle on "Generic" which doesn't look like intended behavior.